### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Download Configuration exemples: https://github.com/MarlinFirmware/Configuration
 
 ## In platformio.ini
 Change:   default_envs = mega2560\
-To:       default_envs = STM32F103RET6_creality
+To:       default_envs = STM32F103RET6_creality <-------This is outdated
+
+Correction would be
+          default_envs = STM32F103RE_creality <---------This is the current updated 
 
 ## In Configuration.h
 


### PR DESCRIPTION
## In platformio.ini
Change:   default_envs = mega2560\
To:       default_envs = STM32F103RET6_creality
To:       default_envs = STM32F103RET6_creality <-------This is outdated (From 2 Years Ago) Compile will fail if you use this

Correction would be
          default_envs = STM32F103RE_creality <---------This is the current updated. Compiled with no issue.

## In Configuration.h